### PR TITLE
Fetch key from metadata: Python SDK

### DIFF
--- a/sdk/python/destination.py
+++ b/sdk/python/destination.py
@@ -36,6 +36,9 @@ from utils import Payload, loadConfig
 
 # XDTtoFnServicer is to be called by dQP to invoke DstFn
 class XDTtoFnServicer(downXDT_pb2_grpc.XDTtoFnServicer):
+    def __init__(self, config):
+        self.config = config
+
     def XDTFnCall(self, request, context):
         log.info("DST: received invocation call %s", request.XDTJSON)
         xdtPayload = Payload.loadFromBytes(request.XDTJSON)
@@ -43,7 +46,7 @@ class XDTtoFnServicer(downXDT_pb2_grpc.XDTtoFnServicer):
         if metadict['is_xdt'] == "true":
             key = metadict['key']
             # fetch data from dQP
-            payloadBytes = FetchFromDQP(key)
+            payloadBytes = FetchFromDQP(key, self.config)
 
             global dstHandler
             # call destination function
@@ -54,8 +57,7 @@ class XDTtoFnServicer(downXDT_pb2_grpc.XDTtoFnServicer):
 
 
 # FetchFromDQP fetches data from dQP to DstFn
-def FetchFromDQP(key):
-    global config
+def FetchFromDQP(key, config):
     serverAddr = config['DQPServerHostname']+config['DQPServerPort']
 
     request = downXDT_pb2.DataRequest(key=key)
@@ -74,9 +76,11 @@ def FetchFromDQP(key):
 def StartDstServer(config, handler):
     global dstHandler
     dstHandler = handler
+
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=config['MaxDstServerThreadsPython']))
+    xdtServicer = XDTtoFnServicer(config=config)
     downXDT_pb2_grpc.add_XDTtoFnServicer_to_server(
-        XDTtoFnServicer(), server)
+        xdtServicer, server)
     server.add_insecure_port("[::]"+config['DstServerPort'])
     server.start()
     server.wait_for_termination()
@@ -84,9 +88,7 @@ def StartDstServer(config, handler):
 
 if __name__ == '__main__':
     log.basicConfig(level=log.INFO)
-    global config
     config = loadConfig()
-
 
     def handler(payload):
         log.info("destination received payload of length %d", len(payload))

--- a/sdk/python/destination.py
+++ b/sdk/python/destination.py
@@ -39,15 +39,18 @@ class XDTtoFnServicer(downXDT_pb2_grpc.XDTtoFnServicer):
     def XDTFnCall(self, request, context):
         log.info("DST: received invocation call %s", request.XDTJSON)
         xdtPayload = Payload.loadFromBytes(request.XDTJSON)
-        key = xdtPayload.Key
+        metadict = dict(context.invocation_metadata())
+        if metadict['is_xdt'] == "true":
+            key = metadict['key']
+            # fetch data from dQP
+            payloadBytes = FetchFromDQP(key)
 
-        # fetch data from dQP
-        payloadBytes = FetchFromDQP(key)
-
-        global dstHandler
-        # call destination function
-        message, ok = dstHandler(payloadBytes)
-        return downXDT_pb2.InvocationResponse(message=message, ok=ok)
+            global dstHandler
+            # call destination function
+            message, ok = dstHandler(payloadBytes)
+            return downXDT_pb2.InvocationResponse(message=message, ok=ok)
+        else:
+            return downXDT_pb2.InvocationResponse(message=b'', ok=False)
 
 
 # FetchFromDQP fetches data from dQP to DstFn

--- a/sdk/python/source.py
+++ b/sdk/python/source.py
@@ -47,8 +47,6 @@ def splitPayload(xdtPayload):
     log.info("%s %s", [b for b in payloadData[0:9]], [
              b for b in payloadData[len(payloadData)-9:]])
     xdtPayload.Data = b''
-    xdtPayload.Key = key
-    xdtPayload.IsXDT = True
     return key, payloadData, xdtPayload
 
 

--- a/sdk/python/test.py
+++ b/sdk/python/test.py
@@ -34,7 +34,7 @@ log.basicConfig(level=log.INFO)
 class UnitTest(unittest.TestCase):
     def test_splitPayload(self):
         payloadToSplit = Payload(
-            FunctionName="foo", Data=b'0123456789', Key="", IsXDT=False)
+            FunctionName="foo", Data=b'0123456789')
         key, data, xdtPayload = splitPayload(payloadToSplit)
         log.info("Generated Key is %s", key)
         assert data == b'0123456789'
@@ -53,13 +53,13 @@ class UnitTest(unittest.TestCase):
 class IntegTest(unittest.TestCase):
     def test_Invoke_XDT(self):
         data = bytes(os.urandom(1024 * 1024 * 10))
-        payload = Payload(FunctionName="foo", Data=data, Key="", IsXDT=False)
+        payload = Payload(FunctionName="foo", Data=data)
         message, ok = InvokeWithXDT(URL=config['ProxyHostname']+config['ProxyPort'], xdtPayload=payload, config=config)
         log.info("destination returned %s %s", message, ok)
 
     def test_Timeout(self):
         data = bytes(os.urandom(1024 * 1024))
-        payload = Payload(FunctionName="foo", Data=data, Key="", IsXDT=False)
+        payload = Payload(FunctionName="foo", Data=data)
         try:
             InvokeWithXDT(URL=config['ProxyHostname']+config['ProxyPort'], xdtPayload=payload, config=config)
         except grpc.RpcError as e:

--- a/sdk/python/utils.py
+++ b/sdk/python/utils.py
@@ -27,29 +27,22 @@ from environs import Env
 class Payload:
     FunctionName: str
     Data: bytes
-    Key: str
-    IsXDT: bool
 
-    def __init__(self, FunctionName, Data, Key, IsXDT):
+    def __init__(self, FunctionName, Data):
         self.FunctionName = FunctionName
         self.Data = Data
-        self.Key = Key
-        self.IsXDT = IsXDT
 
     def tobytes(self):
         objectDict = dict()
         objectDict['FunctionName'] = self.FunctionName
         objectDict['Data'] = ''
-        objectDict['Key'] = self.Key
-        objectDict['IsXDT'] = self.IsXDT
         return bytes(json.dumps(objectDict), 'utf-8')
 
     @classmethod
     def loadFromBytes(self, jsonBytes):
         jsonDump = jsonBytes.decode('utf-8')
         objectDict = json.loads(jsonDump)
-        return Payload(objectDict['FunctionName'], bytes(objectDict['Data'], 'utf-8'), objectDict['Key'],
-                       objectDict['IsXDT'])
+        return Payload(objectDict['FunctionName'], bytes(objectDict['Data'], 'utf-8'))
 
 
 def loadConfig():


### PR DESCRIPTION
Fetch key from metadata instead of the payload.
Remove `key` and `is_xdt` field from payload class.